### PR TITLE
Implement basic semantic check for while loop

### DIFF
--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -23,6 +23,7 @@ import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
 import org.graalvm.polyglot.Value;
 import org.graalvm.python.embedding.GraalPyResources;
+import org.opensearch.python.phase.SemanticAnalyzer;
 import org.opensearch.script.ScriptException;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -53,6 +54,8 @@ public class ExecutionUtils {
             Map<String, ?> params,
             Map<String, ?> doc,
             Double score) {
+        SemanticAnalyzer analyzer = new SemanticAnalyzer(code);
+        analyzer.checkSemantic();
         try (final ExecutorService executor = threadPool.executor(ThreadPool.Names.GENERIC);
                 // A working context without capabilities to import packages:
                 // Context context = Context.newBuilder("python")

--- a/src/main/java/org/opensearch/python/phase/SemanticAnalyzer.java
+++ b/src/main/java/org/opensearch/python/phase/SemanticAnalyzer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.python.phase;
+
+import java.util.List;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.opensearch.python.antlr.Python3Lexer;
+import org.opensearch.python.antlr.Python3Parser;
+import org.opensearch.python.antlr.Python3ParserBaseListener;
+import org.opensearch.script.ScriptException;
+
+public class SemanticAnalyzer {
+    private final String code;
+    private Python3Lexer lexer;
+    private CommonTokenStream tokens;
+    private Python3Parser parser;
+
+    public SemanticAnalyzer(String code) {
+        this.code = code;
+        lexer = new Python3Lexer(CharStreams.fromString(code));
+        tokens = new CommonTokenStream(lexer);
+        parser = new Python3Parser(tokens);
+    }
+
+    public void checkSemantic() {
+        try {
+            // Parse the input as a statement (stmt is the rule for statements in Python)
+            ParseTree tree = parser.file_input();
+
+            // Walk the parse tree to perform semantic checks
+            Python3SemanticCheckParser semanticCheckParser = new Python3SemanticCheckParser();
+            new org.antlr.v4.runtime.tree.ParseTreeWalker().walk(semanticCheckParser, tree);
+        } catch (Exception e) {
+            throw new ScriptException("compile error", e, List.of(), code, "python");
+        }
+    }
+
+    public static class Python3SemanticCheckParser extends Python3ParserBaseListener {
+        @Override
+        public void enterWhile_stmt(Python3Parser.While_stmtContext ctx) {
+            // Check where while has an escape
+            if (ctx.test().getText().equals("True")) {
+                if (ctx.children.stream()
+                        .noneMatch(Python3SemanticCheckParser::containsEscapeRecursive)) {
+                    throw new IllegalArgumentException("no paths escape from while loop");
+                }
+            } else if (ctx.test().getText().equals("False")) {
+                throw new IllegalArgumentException("extraneous while loop");
+            }
+        }
+
+        private static boolean containsEscapeRecursive(ParseTree node) {
+            if (node instanceof Python3Parser.Break_stmtContext) {
+                return true;
+            }
+            if (node instanceof Python3Parser.Return_stmtContext) {
+                return true;
+            }
+            if (node instanceof Python3Parser.Raise_stmtContext) {
+                return true;
+            }
+            // Recurse
+            for (int i = 0; i < node.getChildCount(); i++) {
+                if (containsEscapeRecursive(node.getChild(i))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/yamlRestTest/resources/rest-api-spec/test/go_wrong.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/go_wrong.yml
@@ -1,10 +1,38 @@
-"Test infinite loop via _execute":
+"Test while true loop via _execute":
   - do:
       catch: bad_request
       python.execute:
         body:
           script:
             source: "while True:\n  pass"
+
+  - match: { error.root_cause.0.type: "script_exception" }
+  - match: { error.root_cause.0.reason: "compile error" }
+  - match: { error.caused_by.type: "illegal_argument_exception" }
+  - match: { error.caused_by.reason: "no paths escape from while loop" }
+
+---
+"Test extraneous while loop via _execute":
+  - do:
+      catch: bad_request
+      python.execute:
+        body:
+          script:
+            source: "while False:\n  pass"
+
+  - match: { error.root_cause.0.type: "script_exception" }
+  - match: { error.root_cause.0.reason: "compile error" }
+  - match: { error.caused_by.type: "illegal_argument_exception" }
+  - match: { error.caused_by.reason: "extraneous while loop" }
+
+---
+"Test infinite loop via _execute":
+  - do:
+      catch: bad_request
+      python.execute:
+        body:
+          script:
+            source: "while 1 == 1:\n  pass"
 
   - match: { error.root_cause.0.type: "script_exception" }
   - match: { error.root_cause.0.reason: "Script execution timed out after 20 seconds" }


### PR DESCRIPTION
## Description

This implementation basically checks two conditions:
```python
while True:
    [any statement but no return, raise, or break ]
```
It will report a compiler error: "no paths escape from while loop"

```python
while False:
   [any statement]
```
It will report a compiler error: "extraneous while loop"

Reference: https://github.com/opensearch-project/OpenSearch/blob/f1825fd45bd56e368391994f1310e1d18231e1b3/modules/lang-painless/src/main/java/org/opensearch/painless/phase/DefaultSemanticAnalysisPhase.java#L462

## Related issues

Resolves #10 