### PR TITLE
Move executor outside try-with-resources to prevent thread pool closure

### DIFF
--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -53,21 +53,21 @@ public class ExecutionUtils {
             Map<String, ?> params,
             Map<String, ?> doc,
             Double score) {
-        try (final ExecutorService executor = threadPool.executor(ThreadPool.Names.GENERIC);
-                // A working context without capabilities to import packages:
-                // Context context = Context.newBuilder("python")
-                //            .sandbox(SandboxPolicy.TRUSTED)
-                //            .allowHostAccess(HostAccess.ALL).build()
-                final Context context =
-                        GraalPyResources.contextBuilder()
-                                .sandbox(SandboxPolicy.TRUSTED)
-                                .allowHostAccess(HostAccess.ALL)
-                                // The following 2 options are necessary for importing 3-rd party
-                                // libraries
-                                // that load native libraries
-                                .allowExperimentalOptions(true)
-                                .option("python.IsolateNativeModules", "true")
-                                .build()) {
+        final ExecutorService executor = threadPool.executor(ThreadPool.Names.GENERIC);
+        // A working context without capabilities to import packages:
+        // Context context = Context.newBuilder("python")
+        //            .sandbox(SandboxPolicy.TRUSTED)
+        //            .allowHostAccess(HostAccess.ALL).build()
+        try (final Context context =
+                GraalPyResources.contextBuilder()
+                        .sandbox(SandboxPolicy.TRUSTED)
+                        .allowHostAccess(HostAccess.ALL)
+                        // The following 2 options are necessary for importing 3-rd party
+                        // libraries
+                        // that load native libraries
+                        .allowExperimentalOptions(true)
+                        .option("python.IsolateNativeModules", "true")
+                        .build()) {
             final Future<Value> futureResult =
                     executor.submit(() -> executeWorker(context, code, params, doc, score));
             try {


### PR DESCRIPTION
# Description
The executor was declared inside try-with-resources block, causing the thread pool to be automatically closed after the first task execution. This made subsequent Python script executions fail. 

Fix:
- Moved the executor declaration outside the try-with-resources block to maintain thread pool availability for multiple executions.  