### PR TITLE
Add asynchronous warm up

### DIFF
--- a/src/main/java/org/opensearch/python/PythonModulePlugin.java
+++ b/src/main/java/org/opensearch/python/PythonModulePlugin.java
@@ -7,25 +7,38 @@ package org.opensearch.python;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
+import org.opensearch.env.NodeEnvironment;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.python.action.PythonExecuteAction;
+import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptEngine;
+import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+import org.opensearch.watcher.ResourceWatcherService;
 
 /**
  *
@@ -40,11 +53,50 @@ import org.opensearch.threadpool.ThreadPool;
  *
  */
 public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPlugin {
+    private static final Logger logger = LogManager.getLogger();
+    private static final int WARMUP_DELAY_SECONDS = 5;
+    private ThreadPool threadPool;
+
     public PythonModulePlugin() {}
 
     @Override
     public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return new PythonScriptEngine(new ThreadPool(settings));
+    }
+
+    @Override
+    public Collection<Object> createComponents(
+            Client client,
+            ClusterService clusterService,
+            ThreadPool threadPool,
+            ResourceWatcherService resourceWatcherService,
+            ScriptService scriptService,
+            NamedXContentRegistry xContentRegistry,
+            Environment environment,
+            NodeEnvironment nodeEnvironment,
+            NamedWriteableRegistry namedWriteableRegistry,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            Supplier<RepositoriesService> repositoriesServiceSupplier) {
+
+        this.threadPool = threadPool;
+
+        // Asynchronously warm up Python engine to reduce cold start latency
+        threadPool.schedule(
+                () -> {
+                    try {
+                        logger.info("Starting Python engine warmup...");
+                        long startTime = System.currentTimeMillis();
+                        ExecutionUtils.executePythonAsString(threadPool, "1+1", null, null, null);
+                        long duration = System.currentTimeMillis() - startTime;
+                        logger.info("Python engine warmed up successfully in {}ms", duration);
+                    } catch (Exception e) {
+                        logger.warn("Python engine warmup failed", e);
+                    }
+                },
+                TimeValue.timeValueSeconds(WARMUP_DELAY_SECONDS),
+                ThreadPool.Names.GENERIC);
+
+        return Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
# Description
When executing the first Python script, there is a significant cold start latency (over 2 seconds) in the GraalVM Polyglot 
engine. To mitigate this issue, this PR implemented an asynchronous warm-up mechanism that runs a simple Python script 
during plugin initialization, which significantly reduces the cold start latency from over 2 seconds to under 1 second.

Resolves #13 