### PR TITLE
Fix context closed error by extracting value before context close

### DIFF
--- a/src/main/java/org/opensearch/python/PythonScoreScript.java
+++ b/src/main/java/org/opensearch/python/PythonScoreScript.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
-import org.graalvm.polyglot.Value;
 import org.opensearch.script.ScoreScript;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.threadpool.ThreadPool;
@@ -109,11 +108,12 @@ public class PythonScoreScript {
                 Map<String, ?> params,
                 Map<String, ?> doc,
                 double score) {
-            Value evaluatedVal = ExecutionUtils.executePython(threadPool, code, params, doc, score);
+            Object evaluatedVal =
+                    ExecutionUtils.executePython(threadPool, code, params, doc, score);
             if (evaluatedVal == null) {
                 return 0;
             }
-            return evaluatedVal.asDouble();
+            return ((Number) evaluatedVal).doubleValue();
         }
     }
 }


### PR DESCRIPTION
## Description
This implementation extracts and converts values while the context is still active, preventing the closed context error.
Therefore, now the plugin can handle no-output cases (e.g., pass statements)  and convert other types (beyond String/boolean/number) to String format.

Examples:
```
# Command
curl --location 'http://localhost:9200/_scripts/python/_execute' \
--header 'Content-Type: application/json' \
--data '{
    "script": {
        "source": "pass"
    }
}'

# Response
{"result":""}
```

```
# Command
curl --location 'http://localhost:9200/_scripts/python/_execute' \
--header 'Content-Type: application/json' \
--data '{
    "script": {
        "source": "[i*2 for i in range(3)]"
    }
}'

# Response
{"result":"[0, 2, 4]"}
```

## Related Issues
Resolves #33 