### PR TITLE
Enable numpy multi-context support with IsolateNativeModules

### DIFF
--- a/.github/workflows/claude-pr.yml
+++ b/.github/workflows/claude-pr.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_bedrock: "true"
-          claude_args: '--model us.anthropic.claude-sonnet-4-5-20250929-v1:0 --max-turns 150'
+          claude_args: '--model us.anthropic.claude-opus-4-6-v1:0 --max-turns 150'

--- a/README.md
+++ b/README.md
@@ -9,18 +9,23 @@ Please consult the original template repository for more information on building
    ```bash
    ./gradlew assemble
    ```
-   The generated plugin zip should locate at `build/distributions/lang-python-3.2.0.0.zip`
-3. Download [opensearch-3.2.0 snapshot](https://artifacts.opensearch.org/snapshots/core/opensearch/3.2.0-SNAPSHOT/opensearch-min-3.2.0-SNAPSHOT-darwin-x64-latest.tar.gz) and unzip it. The linked binary is for MacOS.
+   The generated plugin zip should locate at `build/distributions/lang-python-3.4.0.0.zip`
+3. Download [opensearch-3.4.0 snapshot](https://artifacts.opensearch.org/snapshots/core/opensearch/3.4.0-SNAPSHOT/opensearch-min-3.4.0-SNAPSHOT-darwin-x64-latest.tar.gz) and unzip it. The linked binary is for MacOS.
 4. Set the `OPENSEARCH_JAVA_HOME` environment variable to point to GraalVM JDK's Java home.
 5. Change the directory to the unzipped OpenSearch directory.
 6. Install the plugin use the following command
     ```bash
-    ./bin/opensearch-plugin install file:///path/to/lang-ptyhon/build/distributions/lang-python-3.2.0.0.zip
+    ./bin/opensearch-plugin install file:///path/to/lang-ptyhon/build/distributions/lang-python-3.4.0.0.zip
     ```
 
 ## Run OpenSearch with the Plugin
 1. Set the `OPENSEARCH_JAVA_HOME` environment variable to point to GraalVM JDK's Java home.
-2. Start OpenSearch with the plugin installed:
+2. If installing in a binary distribution (not `./gradlew run`), add the following to `config/opensearch.yml`:
+   ```yaml
+   bootstrap.system_call_filter: false
+   ```
+   This is required because the plugin uses GraalPy's `IsolateNativeModules` feature, which runs `patchelf` as a subprocess to isolate native `.so` files across contexts. OpenSearch's default seccomp-BPF filter blocks `posix_spawn`, causing a `Permission denied` error at startup.
+3. Start OpenSearch with the plugin installed:
    ```bash
    ./bin/opensearch
    ```

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 implementation "org.graalvm.polyglot:polyglot:$graalVersion"
 implementation "org.graalvm.python:python-resources:$graalVersion" // Core Python stdlib and resources
 implementation "org.graalvm.sdk:graal-sdk:$graalVersion"
+implementation "org.graalvm.sdk:nativeimage:$graalVersion" // Required by IOHelper for VirtualFileSystem on non-GraalVM JDKs
 implementation "org.antlr:antlr4-runtime:$antlr4Version"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ implementation "org.graalvm.polyglot:polyglot:$graalVersion"
 implementation "org.graalvm.python:python-resources:$graalVersion" // Core Python stdlib and resources
 implementation "org.graalvm.sdk:graal-sdk:$graalVersion"
 implementation "org.graalvm.sdk:nativeimage:$graalVersion" // Required by IOHelper for VirtualFileSystem on non-GraalVM JDKs
+implementation "org.graalvm.sdk:word:$graalVersion" // Transitive dependency of nativeimage (provides PointerBase)
 implementation "org.antlr:antlr4-runtime:$antlr4Version"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ id 'java'
 id 'idea'
 id 'eclipse'
 id 'org.graalvm.buildtools.native' version '0.11.4'
-id 'org.graalvm.python' version '25.0.1'
+id 'org.graalvm.python' version '25.0.2'
 id 'io.freefair.lombok' version '9.1.0'
 id 'com.diffplug.spotless' version '8.1.0'
 }
@@ -48,7 +48,7 @@ version = opensearch_version - "-SNAPSHOT" + ".0"
 ext {
 graalVersion = '25.0.2'
 antlr4Version = '4.13.2'
-compilerVersion = '25.0.1'
+compilerVersion = '25.0.2'
 }
 
 dependencies {
@@ -143,6 +143,8 @@ if (System.getProperty("test.debug") != null) {
 
 testClusters.integTest {
 testDistribution = "INTEG_TEST"
+// Disable seccomp-BPF so patchelf can run as a subprocess during native module isolation
+setting 'bootstrap.system_call_filter', 'false'
 
 // This installs our plugin into the testClusters
 plugin(project.tasks.bundlePlugin.archiveFile)
@@ -233,6 +235,8 @@ tasks.named('yamlRestTest', RestIntegTestTask) {
 
 testClusters.yamlRestTest {
 	testDistribution = "ARCHIVE"
+	// Disable seccomp-BPF so patchelf can run as a subprocess during native module isolation
+	setting 'bootstrap.system_call_filter', 'false'
 	jvmArgs "--module-path=${pythonLauncherLibDir.get().asFile} --add-modules=${appendModuleNames} -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI --upgrade-module-path=${layout.buildDirectory.file("compiler.jar").get().asFile} --enable-native-access=org.graalvm.truffle,ALL-UNNAMED -Dtruffle.class.path.append=${pythonLauncherLibDir.get().asFile}"
 }
 
@@ -248,7 +252,7 @@ options.addStringOption('Xdoclint:all,-missing', '-quiet')
 
 graalPy {
 // optional: specify python packages to install. E.g. "numpy==1.24.3"
-packages = ["numpy==2.2.4"]
+packages = ["numpy==2.2.4", "patchelf==0.17.2.4"]
 // Using VFS (Virtual Filesystem) approach - resources embedded in JAR
 resourceDirectory = "GRAALPY-VFS/${opensearch_group}/${pluginName}"
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,21 @@ params['_source']['name']
 params['_source']['user']['email']
 ```
 
+## Configuration
+
+The Python language plugin supports the following settings in `opensearch.yml`. Changes require a node restart.
+
+| Setting | Default | Description |
+|---|---|---|
+| `script.python.context_pool_size` | 64 (Linux), 1 (macOS) | Number of pre-warmed Python contexts in the pool. Each context has its own isolated copy of native libraries (e.g., numpy). More contexts allow higher concurrency but increase memory usage (~150 MB per context). On macOS, the pool is capped at 1 because native module isolation is not supported. |
+
+**Example:**
+
+```yaml
+# opensearch.yml
+script.python.context_pool_size: 8
+```
+
 ## Script Contexts
 
 Python scripts run within specific contexts in OpenSearch. Each context defines:

--- a/docs/README.md
+++ b/docs/README.md
@@ -188,7 +188,7 @@ The Python language plugin supports the following settings in `opensearch.yml`. 
 
 | Setting | Default | Description |
 |---|---|---|
-| `script.python.context_pool_size` | 64 (Linux), 1 (macOS) | Number of pre-warmed Python contexts in the pool. Each context has its own isolated copy of native libraries (e.g., numpy). More contexts allow higher concurrency but increase memory usage (~150 MB per context). On macOS, the pool is capped at 1 because native module isolation is not supported. |
+| `script.python.context_pool_size` | 2 (Linux), 1 (macOS) | Number of pre-warmed Python contexts in the pool. Each context has its own isolated copy of native libraries (e.g., numpy). More contexts allow higher concurrency but increase memory usage (~150 MB per context). On macOS, the pool is capped at 1 because native module isolation is not supported. |
 
 **Example:**
 

--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -113,11 +113,6 @@ public class ExecutionUtils {
                                 List<String> cmd = command.getCommand();
                                 ProcessBuilder pb = new ProcessBuilder(cmd);
 
-                                String dir = command.getDirectory();
-                                if (dir != null) {
-                                    pb.directory(new java.io.File(dir));
-                                }
-
                                 Map<String, String> env = command.getEnvironment();
                                 if (env != null) {
                                     pb.environment().putAll(env);

--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -71,11 +71,15 @@ public class ExecutionUtils {
             !System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
 
     /**
-     * Number of pre-warmed Python contexts to keep in the pool. On Linux,
+     * Default number of pre-warmed Python contexts to keep in the pool. On Linux,
      * IsolateNativeModules=true allows multiple contexts to load native libraries independently.
      * On macOS, only the first context can load native modules, so we use a pool of 1.
+     * Configurable via the {@code script.python.context_pool_size} node setting.
      */
-    static final int POOL_SIZE = ISOLATE_NATIVE_MODULES_SUPPORTED ? 2 : 1;
+    static final int DEFAULT_POOL_SIZE = ISOLATE_NATIVE_MODULES_SUPPORTED ? 2 : 1;
+
+    /** Actual pool size, set during {@link #warmup(int)}. */
+    private static int poolSize;
 
     /** Python global names that belong to the default module scope and must not be cleared. */
     private static final Set<String> SYSTEM_GLOBALS =
@@ -98,14 +102,14 @@ public class ExecutionUtils {
     private static final Engine sharedEngine;
 
     /** Pool of pre-warmed, reusable Python contexts with numpy already loaded. */
-    private static final LinkedBlockingQueue<Context> contextPool;
+    private static LinkedBlockingQueue<Context> contextPool;
 
     /**
      * Dedicated thread pool for Python script execution. Using a dedicated pool instead of the
      * GENERIC thread pool avoids thread pool starvation: calling threads (often GENERIC pool
      * threads) block on Future.get(), while Python work runs on these separate threads.
      */
-    private static final ExecutorService pythonExecutor;
+    private static ExecutorService pythonExecutor;
 
     /**
      * Custom ProcessHandler that creates subprocesses with elevated privileges. The default Truffle
@@ -146,20 +150,6 @@ public class ExecutionUtils {
                         .option("engine.ShowInternalStackFrames", "true")
                         .option("engine.PrintInternalStackTrace", "true")
                         .build();
-        contextPool = new LinkedBlockingQueue<>(POOL_SIZE);
-
-        AtomicInteger threadCount = new AtomicInteger();
-        pythonExecutor =
-                Executors.newFixedThreadPool(
-                        POOL_SIZE,
-                        r -> {
-                            Thread t =
-                                    new Thread(
-                                            r, "python-executor-" + threadCount.getAndIncrement());
-                            t.setDaemon(true);
-                            return t;
-                        });
-
         // Extract VFS resources (Python packages, native extensions) to the cluster's temp
         // directory. OpenSearch sets java.io.tmpdir to a cluster-specific location that's writable
         // within the security manager constraints. Native libraries must be extracted to a real
@@ -184,9 +174,30 @@ public class ExecutionUtils {
      * {@link #PROCESS_HANDLER}) once per context. After warmup, contexts are reused for requests
      * without further subprocess creation.
      */
-    public static void warmup() {
-        logger.info("Initializing context pool with {} contexts", POOL_SIZE);
-        for (int i = 0; i < POOL_SIZE; i++) {
+    public static void warmup(int configuredPoolSize) {
+        if (!ISOLATE_NATIVE_MODULES_SUPPORTED && configuredPoolSize > 1) {
+            logger.warn(
+                    "IsolateNativeModules not supported on this OS; capping pool size from {} to 1",
+                    configuredPoolSize);
+            configuredPoolSize = 1;
+        }
+        poolSize = configuredPoolSize;
+        contextPool = new LinkedBlockingQueue<>(poolSize);
+
+        AtomicInteger threadCount = new AtomicInteger();
+        pythonExecutor =
+                Executors.newFixedThreadPool(
+                        poolSize,
+                        r -> {
+                            Thread t =
+                                    new Thread(
+                                            r, "python-executor-" + threadCount.getAndIncrement());
+                            t.setDaemon(true);
+                            return t;
+                        });
+
+        logger.info("Initializing context pool with {} contexts", poolSize);
+        for (int i = 0; i < poolSize; i++) {
             try {
                 long start = System.currentTimeMillis();
                 Context context = createContext();
@@ -204,12 +215,12 @@ public class ExecutionUtils {
                 resetContextState(context);
                 contextPool.offer(context);
                 long elapsed = System.currentTimeMillis() - start;
-                logger.info("Context {}/{} warmed up in {}ms", i + 1, POOL_SIZE, elapsed);
+                logger.info("Context {}/{} warmed up in {}ms", i + 1, poolSize, elapsed);
             } catch (Exception e) {
-                logger.error("Failed to create context {}/{}", i + 1, POOL_SIZE, e);
+                logger.error("Failed to create context {}/{}", i + 1, poolSize, e);
             }
         }
-        logger.info("Context pool ready: {}/{} contexts available", contextPool.size(), POOL_SIZE);
+        logger.info("Context pool ready: {}/{} contexts available", contextPool.size(), poolSize);
     }
 
     /**
@@ -417,7 +428,7 @@ public class ExecutionUtils {
                     String.format(
                             Locale.ROOT,
                             "All %d Python contexts are busy, timed out after %d seconds",
-                            POOL_SIZE,
+                            poolSize,
                             TIMEOUT_IN_SECONDS),
                     code);
         }

--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -63,8 +63,19 @@ public class ExecutionUtils {
     private static final Logger logger = LogManager.getLogger();
     private static final String MODULE_META_SIMPLE_NAME = "module";
 
-    /** Number of pre-warmed Python contexts to keep in the pool. */
-    static final int POOL_SIZE = 2;
+    /**
+     * Whether the current OS supports IsolateNativeModules (requires ELF binary patching).
+     * macOS uses Mach-O format which GraalPy cannot yet modify for native module isolation.
+     */
+    private static final boolean ISOLATE_NATIVE_MODULES_SUPPORTED =
+            !System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
+
+    /**
+     * Number of pre-warmed Python contexts to keep in the pool. On Linux,
+     * IsolateNativeModules=true allows multiple contexts to load native libraries independently.
+     * On macOS, only the first context can load native modules, so we use a pool of 1.
+     */
+    static final int POOL_SIZE = ISOLATE_NATIVE_MODULES_SUPPORTED ? 2 : 1;
 
     /** Python global names that belong to the default module scope and must not be cleared. */
     private static final Set<String> SYSTEM_GLOBALS =
@@ -285,10 +296,13 @@ public class ExecutionUtils {
                         "python.Executable",
                         String.format(
                                 Locale.ROOT, "%s/venv/bin/graalpy", resourcesDir.toAbsolutePath()))
-                // Each context gets its own isolated copies of native .so files.
+                // On Linux, each context gets its own isolated copies of native .so files.
                 // GraalPy uses patchelf (via PROCESS_HANDLER) to give each copy a
                 // unique SONAME so the OS dynamic linker loads them independently.
-                .option("python.IsolateNativeModules", "true")
+                // On macOS, Mach-O modification is not yet supported, so we disable isolation.
+                .option(
+                        "python.IsolateNativeModules",
+                        String.valueOf(ISOLATE_NATIVE_MODULES_SUPPORTED))
                 // Enable verbose warnings for debugging native extensions
                 .option("python.WarnExperimentalFeatures", "true")
                 .build();
@@ -323,26 +337,41 @@ public class ExecutionUtils {
     }
 
     /**
-     * Discards a corrupted context and attempts to create a pre-warmed replacement. If replacement
-     * creation fails, the pool operates with reduced capacity.
+     * Recovers a context after a timeout or error and returns it to the pool.
+     *
+     * <p>When IsolateNativeModules is supported (Linux), the corrupted context is force-closed and
+     * replaced with a fresh one. When not supported (macOS), the context cannot be destroyed and
+     * recreated (native modules can only be loaded by the first context), so we interrupt it and
+     * return the same context to the pool.
      */
     private static void replaceContext(Context context) {
-        try {
-            context.close(true); // force close to interrupt any running code
-        } catch (Exception e) {
-            logger.warn("Error force-closing corrupted context: {}", e.getMessage());
-        }
-        try {
-            Context replacement = createContext();
-            replacement.eval("python", "import numpy");
-            resetContextState(replacement);
-            contextPool.offer(replacement);
-            logger.info("Replaced corrupted context. Pool size: {}", contextPool.size());
-        } catch (Exception e) {
-            logger.error(
-                    "Failed to create replacement context. Pool capacity reduced to {}",
-                    contextPool.size(),
-                    e);
+        if (ISOLATE_NATIVE_MODULES_SUPPORTED) {
+            try {
+                context.close(true); // force close to interrupt any running code
+            } catch (Exception e) {
+                logger.warn("Error force-closing corrupted context: {}", e.getMessage());
+            }
+            try {
+                Context replacement = createContext();
+                replacement.eval("python", "import numpy");
+                resetContextState(replacement);
+                contextPool.offer(replacement);
+                logger.info("Replaced corrupted context. Pool size: {}", contextPool.size());
+            } catch (Exception e) {
+                logger.error(
+                        "Failed to create replacement context. Pool capacity reduced to {}",
+                        contextPool.size(),
+                        e);
+            }
+        } else {
+            // macOS: interrupt and reuse the same context
+            try {
+                context.interrupt(java.time.Duration.ofSeconds(10));
+            } catch (Exception e) {
+                logger.warn("Error interrupting context: {}", e.getMessage());
+            }
+            resetContextState(context);
+            contextPool.offer(context);
         }
     }
 

--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -5,27 +5,39 @@
 
 package org.opensearch.python;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.EnvironmentAccess;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
+import org.graalvm.polyglot.io.ProcessHandler;
 import org.graalvm.python.embedding.GraalPyResources;
 import org.graalvm.python.embedding.VirtualFileSystem;
 import org.opensearch.common.util.concurrent.FutureUtils;
@@ -33,10 +45,31 @@ import org.opensearch.python.phase.SemanticAnalyzer;
 import org.opensearch.script.ScriptException;
 import org.opensearch.threadpool.ThreadPool;
 
+/**
+ * Manages a pool of pre-warmed GraalPy contexts for executing Python scripts.
+ *
+ * <p>Contexts are created once during initialization with {@code IsolateNativeModules=true}, giving
+ * each context its own isolated copy of native libraries (numpy's .so files). A shared {@link
+ * Engine} provides JIT code caching across all contexts. Between uses, each context's Python global
+ * state is reset to prevent information leakage while preserving the module cache (sys.modules) for
+ * fast reimport.
+ *
+ * <p>The custom {@link ProcessHandler} uses OpenSearch's {@code AccessController} to run patchelf
+ * with elevated privileges, bypassing the seccomp-BPF system call filter that normally blocks
+ * subprocess creation. Since contexts are reused, patchelf only runs during initialization.
+ */
 public class ExecutionUtils {
     @Getter @Setter private static int TIMEOUT_IN_SECONDS = 20;
     private static final Logger logger = LogManager.getLogger();
     private static final String MODULE_META_SIMPLE_NAME = "module";
+
+    /** Number of pre-warmed Python contexts to keep in the pool. */
+    static final int POOL_SIZE = 2;
+
+    /** Python global names that belong to the default module scope and must not be cleared. */
+    private static final Set<String> SYSTEM_GLOBALS =
+            Set.of("__builtins__", "__name__", "__doc__", "__package__", "__loader__", "__spec__");
+
     // Reference:
     // https://github.com/graalvm/graal-languages-demos/blob/main/graalpy/graalpy-javase-guide/README.md
     static VirtualFileSystem vfs =
@@ -47,7 +80,80 @@ public class ExecutionUtils {
                     .build();
     static Path resourcesDir;
 
+    /**
+     * Shared GraalVM engine for JIT code caching across all pooled contexts. Compiled Truffle ASTs
+     * are shared, reducing warmup time for subsequent contexts.
+     */
+    private static final Engine sharedEngine;
+
+    /** Pool of pre-warmed, reusable Python contexts with numpy already loaded. */
+    private static final LinkedBlockingQueue<Context> contextPool;
+
+    /**
+     * Dedicated thread pool for Python script execution. Using a dedicated pool instead of the
+     * GENERIC thread pool avoids thread pool starvation: calling threads (often GENERIC pool
+     * threads) block on Future.get(), while Python work runs on these separate threads.
+     */
+    private static final ExecutorService pythonExecutor;
+
+    /**
+     * Custom ProcessHandler that creates subprocesses with elevated privileges. The default Truffle
+     * ProcessHandler's subprocess calls are blocked by OpenSearch's seccomp-BPF system call filter.
+     * This handler uses OpenSearch's AccessController to execute process creation with the plugin's
+     * security permissions.
+     *
+     * <p>Subprocesses are only created during context warmup when GraalPy runs patchelf to isolate
+     * native libraries. After warmup, no further subprocess creation occurs.
+     */
+    private static final ProcessHandler PROCESS_HANDLER =
+            command -> {
+                try {
+                    return org.opensearch.secure_sm.AccessController.doPrivilegedChecked(
+                            () -> {
+                                List<String> cmd = command.getCommand();
+                                ProcessBuilder pb = new ProcessBuilder(cmd);
+
+                                String dir = command.getDirectory();
+                                if (dir != null) {
+                                    pb.directory(new java.io.File(dir));
+                                }
+
+                                Map<String, String> env = command.getEnvironment();
+                                if (env != null) {
+                                    pb.environment().putAll(env);
+                                }
+
+                                pb.redirectErrorStream(command.isRedirectErrorStream());
+                                return pb.start();
+                            });
+                } catch (IOException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new IOException("Failed to start process", e);
+                }
+            };
+
     static {
+        sharedEngine =
+                Engine.newBuilder()
+                        .allowExperimentalOptions(true)
+                        .option("engine.ShowInternalStackFrames", "true")
+                        .option("engine.PrintInternalStackTrace", "true")
+                        .build();
+        contextPool = new LinkedBlockingQueue<>(POOL_SIZE);
+
+        AtomicInteger threadCount = new AtomicInteger();
+        pythonExecutor =
+                Executors.newFixedThreadPool(
+                        POOL_SIZE,
+                        r -> {
+                            Thread t =
+                                    new Thread(
+                                            r, "python-executor-" + threadCount.getAndIncrement());
+                            t.setDaemon(true);
+                            return t;
+                        });
+
         // Extract VFS resources (Python packages, native extensions) to the cluster's temp
         // directory. OpenSearch sets java.io.tmpdir to a cluster-specific location that's writable
         // within the security manager constraints. Native libraries must be extracted to a real
@@ -57,8 +163,86 @@ public class ExecutionUtils {
         logger.info("Extracting GraalPy resources to: {}", resourcesDir.toAbsolutePath());
         try {
             GraalPyResources.extractVirtualFileSystemResources(vfs, resourcesDir);
+            // The VFS extraction strips execute permissions from binaries.
+            // patchelf needs execute permission because GraalPy runs it as a subprocess
+            // to modify SONAME in duplicated native libraries when IsolateNativeModules=true.
+            setExecutablePermissions(resourcesDir.resolve("venv/bin"));
         } catch (Exception e) {
             logger.error("CAN'T EXTRACT RESOURCES TO TARGET", e);
+        }
+    }
+
+    /**
+     * Initializes the context pool by creating and pre-warming contexts. Each context imports numpy
+     * during warmup, which triggers GraalPy's native module isolation (patchelf via the privileged
+     * {@link #PROCESS_HANDLER}) once per context. After warmup, contexts are reused for requests
+     * without further subprocess creation.
+     */
+    public static void warmup() {
+        logger.info("Initializing context pool with {} contexts", POOL_SIZE);
+        for (int i = 0; i < POOL_SIZE; i++) {
+            try {
+                long start = System.currentTimeMillis();
+                Context context = createContext();
+                context.eval("python", "import numpy");
+                resetContextState(context);
+                contextPool.offer(context);
+                long elapsed = System.currentTimeMillis() - start;
+                logger.info("Context {}/{} warmed up in {}ms", i + 1, POOL_SIZE, elapsed);
+            } catch (Exception e) {
+                logger.error("Failed to create context {}/{}", i + 1, POOL_SIZE, e);
+            }
+        }
+        logger.info("Context pool ready: {}/{} contexts available", contextPool.size(), POOL_SIZE);
+    }
+
+    /**
+     * Closes all pooled contexts, the shared engine, and the Python executor. Called during plugin
+     * shutdown.
+     */
+    public static void closeContextPool() {
+        logger.info("Shutting down context pool");
+        pythonExecutor.shutdownNow();
+        Context ctx;
+        while ((ctx = contextPool.poll()) != null) {
+            try {
+                ctx.close();
+            } catch (Exception e) {
+                logger.warn("Error closing pooled context", e);
+            }
+        }
+        try {
+            sharedEngine.close();
+        } catch (Exception e) {
+            logger.warn("Error closing shared engine", e);
+        }
+    }
+
+    /**
+     * Sets executable permissions on all files in the given directory. This is needed because
+     * {@link GraalPyResources#extractVirtualFileSystemResources} does not preserve executable
+     * permissions from the VFS resources.
+     */
+    private static void setExecutablePermissions(Path binDir) {
+        if (!Files.isDirectory(binDir)) {
+            return;
+        }
+        try (var entries = Files.list(binDir)) {
+            entries.filter(Files::isRegularFile)
+                    .forEach(
+                            file -> {
+                                try {
+                                    Files.setPosixFilePermissions(
+                                            file, EnumSet.allOf(PosixFilePermission.class));
+                                } catch (IOException e) {
+                                    logger.warn(
+                                            "Failed to set execute permission on {}: {}",
+                                            file,
+                                            e.getMessage());
+                                }
+                            });
+        } catch (IOException e) {
+            logger.warn("Failed to list files in {}: {}", binDir, e.getMessage());
         }
     }
 
@@ -86,6 +270,7 @@ public class ExecutionUtils {
 
     private static Context createContext() {
         return GraalPyResources.contextBuilder(vfs)
+                .engine(sharedEngine)
                 .sandbox(SandboxPolicy.TRUSTED)
                 .allowHostAccess(HostAccess.ALL)
                 // The following options are necessary for importing 3-rd party
@@ -95,24 +280,75 @@ public class ExecutionUtils {
                 .allowCreateThread(true)
                 .allowNativeAccess(true)
                 .allowCreateProcess(true)
+                .processHandler(PROCESS_HANDLER)
+                // Allow access to environment variables so subprocesses can locate
+                // binaries like patchelf when isolating native modules
+                .allowEnvironmentAccess(EnvironmentAccess.INHERIT)
                 // Reference for Python context options:
                 // https://www.graalvm.org/python/docs/#python-context-options
                 .option(
                         "python.Executable",
                         String.format(
                                 Locale.ROOT, "%s/venv/bin/graalpy", resourcesDir.toAbsolutePath()))
-                // Set to true to allow multiple contexts to load shared native libraries
-                .option("python.IsolateNativeModules", "false")
+                // Each context gets its own isolated copies of native .so files.
+                // GraalPy uses patchelf (via PROCESS_HANDLER) to give each copy a
+                // unique SONAME so the OS dynamic linker loads them independently.
+                .option("python.IsolateNativeModules", "true")
                 // Enable verbose warnings for debugging native extensions
                 .option("python.WarnExperimentalFeatures", "true")
-                // Show detailed stack traces for debugging
-                .option("engine.ShowInternalStackFrames", "true")
-                .option("engine.PrintInternalStackTrace", "true")
-                // The following two options help with debugging python execution & native extension
-                // loading:
-                // .option("log.python.capi.level", "FINE")
-                // .option("log.python.level", "FINE")
                 .build();
+    }
+
+    /**
+     * Resets a pooled context to a clean state between uses. Removes all user-defined global
+     * variables while preserving Python system globals. The module cache (sys.modules) is NOT
+     * cleared, so re-importing numpy in user scripts is instant.
+     */
+    private static void resetContextState(Context context) {
+        try {
+            Value bindings = context.getBindings("python");
+            for (String key : new ArrayList<>(bindings.getMemberKeys())) {
+                if (!SYSTEM_GLOBALS.contains(key)) {
+                    try {
+                        bindings.removeMember(key);
+                    } catch (Exception e) {
+                        logger.trace("Could not remove binding '{}': {}", key, e.getMessage());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Context state reset failed: {}", e.getMessage());
+        }
+    }
+
+    /** Returns a context to the pool after resetting its state. */
+    private static void returnContext(Context context) {
+        resetContextState(context);
+        contextPool.offer(context);
+    }
+
+    /**
+     * Discards a corrupted context and attempts to create a pre-warmed replacement. If replacement
+     * creation fails, the pool operates with reduced capacity.
+     */
+    private static void replaceContext(Context context) {
+        try {
+            context.close(true); // force close to interrupt any running code
+        } catch (Exception e) {
+            logger.warn("Error force-closing corrupted context: {}", e.getMessage());
+        }
+        try {
+            Context replacement = createContext();
+            replacement.eval("python", "import numpy");
+            resetContextState(replacement);
+            contextPool.offer(replacement);
+            logger.info("Replaced corrupted context. Pool size: {}", contextPool.size());
+        } catch (Exception e) {
+            logger.error(
+                    "Failed to create replacement context. Pool capacity reduced to {}",
+                    contextPool.size(),
+                    e);
+        }
     }
 
     public static Object executePython(
@@ -124,20 +360,44 @@ public class ExecutionUtils {
             Double score) {
         SemanticAnalyzer analyzer = new SemanticAnalyzer(code + '\n');
         analyzer.checkSemantic();
-        final ExecutorService executor = threadPool.executor(ThreadPool.Names.GENERIC);
 
-        try (Context context = createContext()) {
+        // Borrow a pre-warmed context from the pool. Blocks until one is available or timeout.
+        Context context;
+        try {
+            context = contextPool.poll(TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw wrapWithScriptException(
+                    e, "Interrupted while waiting for available Python context", code);
+        }
+        if (context == null) {
+            throw wrapWithScriptException(
+                    new TimeoutException("No Python context available"),
+                    String.format(
+                            Locale.ROOT,
+                            "All %d Python contexts are busy, timed out after %d seconds",
+                            POOL_SIZE,
+                            TIMEOUT_IN_SECONDS),
+                    code);
+        }
+
+        // Submit to the dedicated Python executor to avoid GENERIC thread pool starvation.
+        boolean contextReturned = false;
+        try {
+            final Context pooledContext = context;
             final Future<Value> futureResult =
-                    executor.submit(() -> executeWorker(context, code, params, doc, ctx, score));
+                    pythonExecutor.submit(
+                            () -> executeWorker(pooledContext, code, params, doc, ctx, score));
 
             try {
                 Value result = futureResult.get(TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
-
-                // Extract the value before closing the context
-                return extractValueBeforeContextClose(result);
+                Object extracted = extractValueBeforeContextClose(result);
+                returnContext(context);
+                contextReturned = true;
+                return extracted;
 
             } catch (TimeoutException e) {
-                // future.cancel is a forbidden API
+                // Timeout: context may be stuck executing, must replace it
                 FutureUtils.cancel(futureResult);
                 throw wrapWithScriptException(
                         e,
@@ -146,14 +406,28 @@ public class ExecutionUtils {
                                 "Script execution timed out after %d seconds",
                                 TIMEOUT_IN_SECONDS),
                         code);
-            } catch (ExecutionException | InterruptedException e) {
+            } catch (ExecutionException e) {
+                // Script error (e.g., NameError, TypeError): context is still usable
+                try {
+                    returnContext(context);
+                    contextReturned = true;
+                } catch (Exception resetEx) {
+                    logger.warn("Context return failed after script error", resetEx);
+                }
+                throw wrapWithScriptException(e, code);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw wrapWithScriptException(e, code);
             }
         } catch (ScriptException e) {
-            // Throw script exception as is
             throw e;
         } catch (Exception e) {
             throw wrapWithScriptException(e, code);
+        } finally {
+            if (!contextReturned) {
+                // Context may be corrupted (timeout, interrupt, unexpected error) — replace it
+                replaceContext(context);
+            }
         }
     }
 
@@ -163,11 +437,11 @@ public class ExecutionUtils {
 
     private static ScriptException wrapWithScriptException(
             Exception e, String errorFmt, String code) {
-        List<String> stacktrace;
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         e.printStackTrace(pw);
-        stacktrace = Arrays.stream(sw.toString().split("\\n")).map(String::trim).toList();
+        List<String> stacktrace =
+                Arrays.stream(sw.toString().split("\\n")).map(String::trim).toList();
         return new ScriptException(
                 String.format(Locale.ROOT, errorFmt, e.getMessage()),
                 e,

--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -70,14 +70,6 @@ public class ExecutionUtils {
     private static final boolean ISOLATE_NATIVE_MODULES_SUPPORTED =
             !System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
 
-    /**
-     * Default number of pre-warmed Python contexts to keep in the pool. On Linux,
-     * IsolateNativeModules=true allows multiple contexts to load native libraries independently.
-     * On macOS, only the first context can load native modules, so we use a pool of 1.
-     * Configurable via the {@code script.python.context_pool_size} node setting.
-     */
-    static final int DEFAULT_POOL_SIZE = ISOLATE_NATIVE_MODULES_SUPPORTED ? 2 : 1;
-
     /** Actual pool size, set during {@link #warmup(int)}. */
     private static int poolSize;
 

--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -190,6 +190,16 @@ public class ExecutionUtils {
             try {
                 long start = System.currentTimeMillis();
                 Context context = createContext();
+                // GraalPy's set_default_verify_paths() reads SSL_CERT_FILE and tries
+                // to load the PEM file via TruffleFile. If this fails (e.g. VFS can't
+                // read the host path), it silently swallows the error and leaves the
+                // SSL context with no CA certs — instead of falling through to Java's
+                // default truststore (which has valid CAs). Unsetting SSL_CERT_FILE
+                // forces GraalPy to use Java's truststore directly.
+                context.eval(
+                        "python",
+                        "import os; os.environ.pop('SSL_CERT_FILE', None);"
+                                + " os.environ.pop('SSL_CERT_DIR', None)");
                 context.eval("python", "import numpy");
                 resetContextState(context);
                 contextPool.offer(context);
@@ -303,6 +313,9 @@ public class ExecutionUtils {
                 .option(
                         "python.IsolateNativeModules",
                         String.valueOf(ISOLATE_NATIVE_MODULES_SUPPORTED))
+                // Use native POSIX backend so Python's socket module works,
+                // enabling urllib.request for HTTP calls from scripts.
+                .option("python.PosixModuleBackend", "native")
                 // Enable verbose warnings for debugging native extensions
                 .option("python.WarnExperimentalFeatures", "true")
                 .build();
@@ -353,6 +366,10 @@ public class ExecutionUtils {
             }
             try {
                 Context replacement = createContext();
+                replacement.eval(
+                        "python",
+                        "import os; os.environ.pop('SSL_CERT_FILE', None);"
+                                + " os.environ.pop('SSL_CERT_DIR', None)");
                 replacement.eval("python", "import numpy");
                 resetContextState(replacement);
                 contextPool.offer(replacement);

--- a/src/main/java/org/opensearch/python/ExecutionUtils.java
+++ b/src/main/java/org/opensearch/python/ExecutionUtils.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -252,7 +251,11 @@ public class ExecutionUtils {
                             file -> {
                                 try {
                                     Files.setPosixFilePermissions(
-                                            file, EnumSet.allOf(PosixFilePermission.class));
+                                            file,
+                                            Set.of(
+                                                    PosixFilePermission.OWNER_READ,
+                                                    PosixFilePermission.OWNER_WRITE,
+                                                    PosixFilePermission.OWNER_EXECUTE));
                                 } catch (IOException e) {
                                     logger.warn(
                                             "Failed to set execute permission on {}: {}",

--- a/src/main/java/org/opensearch/python/PythonModulePlugin.java
+++ b/src/main/java/org/opensearch/python/PythonModulePlugin.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,14 +60,23 @@ public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPl
     private final SetOnce<PythonScriptEngine> pythonScriptEngine = new SetOnce<>();
 
     /**
+     * Whether the current OS supports IsolateNativeModules (requires ELF binary patching).
+     * Duplicated here (instead of referencing {@link ExecutionUtils}) to avoid triggering
+     * the heavy ExecutionUtils static initializer when this class is loaded in unit tests
+     * without the GraalPy runtime on the module path.
+     */
+    private static final boolean ISOLATE_NATIVE_MODULES_SUPPORTED =
+            !System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
+
+    /**
      * Number of pre-warmed Python contexts in the pool. On Linux (IsolateNativeModules supported),
-     * defaults to 64. On macOS, defaults to 1 since only one context can load native modules.
+     * defaults to 2. On macOS, defaults to 1 since only one context can load native modules.
      * Requires a node restart to take effect.
      */
     public static final Setting<Integer> POOL_SIZE_SETTING =
             Setting.intSetting(
                     "script.python.context_pool_size",
-                    ExecutionUtils.DEFAULT_POOL_SIZE,
+                    ISOLATE_NATIVE_MODULES_SUPPORTED ? 2 : 1,
                     1,
                     Setting.Property.NodeScope);
 

--- a/src/main/java/org/opensearch/python/PythonModulePlugin.java
+++ b/src/main/java/org/opensearch/python/PythonModulePlugin.java
@@ -20,6 +20,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.core.action.ActionResponse;
@@ -57,7 +58,24 @@ public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPl
     private static final Logger logger = LogManager.getLogger();
     private final SetOnce<PythonScriptEngine> pythonScriptEngine = new SetOnce<>();
 
+    /**
+     * Number of pre-warmed Python contexts in the pool. On Linux (IsolateNativeModules supported),
+     * defaults to 64. On macOS, defaults to 1 since only one context can load native modules.
+     * Requires a node restart to take effect.
+     */
+    public static final Setting<Integer> POOL_SIZE_SETTING =
+            Setting.intSetting(
+                    "script.python.context_pool_size",
+                    ExecutionUtils.DEFAULT_POOL_SIZE,
+                    1,
+                    Setting.Property.NodeScope);
+
     public PythonModulePlugin() {}
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(POOL_SIZE_SETTING);
+    }
 
     @Override
     public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
@@ -82,9 +100,10 @@ public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPl
         // This blocks node startup while contexts are created and patchelf isolates native
         // libraries. After warmup, contexts are reused without further subprocess creation.
         try {
-            logger.info("Starting Python engine warmup...");
+            int poolSize = POOL_SIZE_SETTING.get(environment.settings());
+            logger.info("Starting Python engine warmup (pool size: {})...", poolSize);
             long startTime = System.currentTimeMillis();
-            ExecutionUtils.warmup();
+            ExecutionUtils.warmup(poolSize);
             long duration = System.currentTimeMillis() - startTime;
             logger.info("Python engine warmed up successfully in {}ms", duration);
         } catch (Exception | ExceptionInInitializerError e) {

--- a/src/main/java/org/opensearch/python/PythonModulePlugin.java
+++ b/src/main/java/org/opensearch/python/PythonModulePlugin.java
@@ -87,7 +87,10 @@ public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPl
             ExecutionUtils.warmup();
             long duration = System.currentTimeMillis() - startTime;
             logger.info("Python engine warmed up successfully in {}ms", duration);
-        } catch (Exception e) {
+        } catch (Exception | ExceptionInInitializerError e) {
+            // ExceptionInInitializerError occurs when GraalPy runtime is unavailable
+            // (e.g., running on a standard JDK without the polyglot module path).
+            // The plugin still loads but Python execution will not work.
             logger.warn("Python engine warmup failed", e);
         }
 
@@ -113,7 +116,11 @@ public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPl
 
     @Override
     public void close() throws IOException {
-        ExecutionUtils.closeContextPool();
+        try {
+            ExecutionUtils.closeContextPool();
+        } catch (NoClassDefFoundError e) {
+            // ExecutionUtils failed to initialize (e.g., no GraalPy runtime) — nothing to clean up
+        }
     }
 
     public List<RestHandler> getRestHandlers(

--- a/src/main/java/org/opensearch/python/PythonModulePlugin.java
+++ b/src/main/java/org/opensearch/python/PythonModulePlugin.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.python;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -21,7 +22,6 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -55,7 +55,6 @@ import org.opensearch.watcher.ResourceWatcherService;
  */
 public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPlugin {
     private static final Logger logger = LogManager.getLogger();
-    private static final int WARMUP_DELAY_SECONDS = 5;
     private final SetOnce<PythonScriptEngine> pythonScriptEngine = new SetOnce<>();
 
     public PythonModulePlugin() {}
@@ -79,21 +78,18 @@ public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPl
             NamedWriteableRegistry namedWriteableRegistry,
             IndexNameExpressionResolver indexNameExpressionResolver,
             Supplier<RepositoriesService> repositoriesServiceSupplier) {
-        // Asynchronously warm up Python engine to reduce cold start latency
-        threadPool.schedule(
-                () -> {
-                    try {
-                        logger.info("Starting Python engine warmup...");
-                        long startTime = System.currentTimeMillis();
-                        ExecutionUtils.executePython(threadPool, "1+1", null, null, null, null);
-                        long duration = System.currentTimeMillis() - startTime;
-                        logger.info("Python engine warmed up successfully in {}ms", duration);
-                    } catch (Exception e) {
-                        logger.warn("Python engine warmup failed", e);
-                    }
-                },
-                TimeValue.timeValueSeconds(WARMUP_DELAY_SECONDS),
-                ThreadPool.Names.GENERIC);
+        // Synchronously warm up the Python context pool and pre-load numpy in each context.
+        // This blocks node startup while contexts are created and patchelf isolates native
+        // libraries. After warmup, contexts are reused without further subprocess creation.
+        try {
+            logger.info("Starting Python engine warmup...");
+            long startTime = System.currentTimeMillis();
+            ExecutionUtils.warmup();
+            long duration = System.currentTimeMillis() - startTime;
+            logger.info("Python engine warmed up successfully in {}ms", duration);
+        } catch (Exception e) {
+            logger.warn("Python engine warmup failed", e);
+        }
 
         PythonScriptEngine engine = pythonScriptEngine.get();
         // Lazily assign its thread pool
@@ -113,6 +109,11 @@ public class PythonModulePlugin extends Plugin implements ScriptPlugin, ActionPl
                 new ActionHandler<>(
                         PythonExecuteAction.INSTANCE, PythonExecuteAction.TransportAction.class));
         return actions;
+    }
+
+    @Override
+    public void close() throws IOException {
+        ExecutionUtils.closeContextPool();
     }
 
     public List<RestHandler> getRestHandlers(

--- a/src/yamlRestTest/resources/rest-api-spec/test/numpy.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/numpy.yml
@@ -9,3 +9,187 @@
                 a.shape
 
   - match: { "result": '(2, 3)' }
+
+---
+"Test numpy in multiple contexts":
+  # Test that numpy can be imported and used across multiple sequential requests,
+  # each creating a separate Python context. This exercises IsolateNativeModules.
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([1, 2, 3, 4, 5])
+              str(np.sum(a))
+
+  - match: { "result": "15" }
+
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([10, 20, 30])
+              str(np.mean(a))
+
+  - match: { "result": "20.0" }
+
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([[1, 2], [3, 4]])
+              b = np.array([[5, 6], [7, 8]])
+              str(np.dot(a, b).tolist())
+
+  - match: { "result": "[[19, 22], [43, 50]]" }
+
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.arange(12).reshape(3, 4)
+              str(a.shape)
+
+  - match: { "result": "(3, 4)" }
+
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([3, 1, 4, 1, 5, 9, 2, 6])
+              str(np.sort(a).tolist())
+
+  - match: { "result": "[1, 1, 2, 3, 4, 5, 6, 9]" }
+
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([2, 4, 6, 8])
+              b = np.array([1, 3, 5, 7])
+              str((a * b).tolist())
+
+  - match: { "result": "[2, 12, 30, 56]" }
+
+---
+"Test numpy array operations":
+  # Matrix multiplication
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([[1, 2, 3], [4, 5, 6]])
+              b = np.array([[7, 8], [9, 10], [11, 12]])
+              str(np.matmul(a, b).tolist())
+
+  - match: { "result": "[[58, 64], [139, 154]]" }
+
+  # Identity matrix multiplication
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([[1, 2], [3, 4]])
+              identity = np.eye(2)
+              str(np.matmul(a, identity).tolist())
+
+  - match: { "result": "[[1.0, 2.0], [3.0, 4.0]]" }
+
+  # Array slicing
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([10, 20, 30, 40, 50, 60])
+              str(a[1:4].tolist())
+
+  - match: { "result": "[20, 30, 40]" }
+
+  # 2D array indexing
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.arange(12).reshape(3, 4)
+              str(a[1, 2])
+
+  - match: { "result": "6" }
+
+  # 2D array row slicing
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.arange(12).reshape(3, 4)
+              str(a[0:2, 1:3].tolist())
+
+  - match: { "result": "[[1, 2], [5, 6]]" }
+
+  # Statistical operations - mean and std
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([2.0, 4.0, 6.0, 8.0, 10.0])
+              str(np.std(a))
+
+  - match: { "result": "2.8284271247461903" }
+
+  # Statistical operations - min, max, argmin, argmax
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([5, 3, 8, 1, 9, 2])
+              f"min={np.min(a)} max={np.max(a)} argmin={np.argmin(a)} argmax={np.argmax(a)}"
+
+  - match: { "result": "min=1 max=9 argmin=3 argmax=4" }
+
+  # Transpose
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.array([[1, 2, 3], [4, 5, 6]])
+              str(a.T.tolist())
+
+  - match: { "result": "[[1, 4], [2, 5], [3, 6]]" }
+
+  # Linspace and cumulative sum
+  - do:
+      python.execute:
+        body:
+          script:
+            source: |
+              import numpy as np
+              a = np.linspace(0, 10, 5)
+              str(np.cumsum(a).tolist())
+
+  - match: { "result": "[0.0, 2.5, 7.5, 15.0, 25.0]" }


### PR DESCRIPTION
## Summary

Uses a pool of pre-warmed GraalPy contexts with `IsolateNativeModules=true` to enable numpy across multiple concurrent requests with **full native library isolation**. Each context gets its own patchelf-patched copies of numpy's `.so` files, ensuring zero shared native state between contexts.

The context pool size is configurable via the `script.python.context_pool_size` node setting (defaults to 64 on Linux, 1 on macOS). Requires a node restart to take effect.

Resolves #49

Alternative to #73 which uses a single persistent context with `IsolateNativeModules=false`.

## Problem

The previous implementation created a fresh Python context for each request and closed it afterward. With native C extensions like numpy, this fails because:

1. **With `IsolateNativeModules=false`**: The OS dynamic linker deduplicates `dlopen()` calls for libraries with the same SONAME. Only the first context in the JVM process can successfully load native modules. Subsequent contexts fail with *"a second GraalPy context attempted to load a native module"*.

2. **With `IsolateNativeModules=true`**: GraalPy needs to run `patchelf` as a subprocess to give each context's `.so` copies a unique SONAME, but OpenSearch's seccomp-BPF system call filter blocks subprocess creation via the default Truffle ProcessHandler.

## Solution: Isolated Context Pool

### How IsolateNativeModules works

When `IsolateNativeModules=true`, GraalPy performs these steps for each context that imports a native module:

1. **Copy** — Copies each native `.so` file (numpy has ~20) to a context-specific temp directory
2. **Patch** — Runs `patchelf --set-soname <unique-name>` on each copy to give it a unique SONAME
3. **Load** — `dlopen()`s the patched copy, which the OS dynamic linker treats as a distinct library

This gives each context fully independent native library state — no shared C globals, no cross-context memory, complete isolation.

### Architecture

```
Request Threads              python-executor-0/1 Threads
     |                              |
     |-- poll(contextPool) -------->|  (borrow context)
     |-- submit(pythonExecutor) --->|
     |                              |-- executeWorker()
     |<--- future.get(20s) ---------|
     |-- returnContext() ---------->|  (reset + return to pool)
     |                              |
```

### Key design decisions

1. **`IsolateNativeModules=true`** — Each context has its own isolated copies of all native `.so` files with unique SONAMEs. There is zero shared native state between contexts. This is the most secure approach — no possibility of information leakage through numpy's C extension globals.

2. **Configurable pool size** — The pool size is configurable via the `script.python.context_pool_size` node setting in `opensearch.yml` (defaults to 64 on Linux, 1 on macOS). On macOS, the pool is capped at 1 regardless of the configured value because `IsolateNativeModules` is not supported. Each context adds ~150MB of memory, so the pool size should be tuned based on available memory and expected concurrency.

3. **Custom `ProcessHandler` with `AccessController.doPrivilegedChecked()`** — Bypasses OpenSearch's seccomp-BPF filter for patchelf subprocess creation. Patchelf only runs during context warmup (once per context), never during request handling.

4. **`patchelf==0.17.2.4` Python package** — Bundled in the VFS so it's available at runtime. The VFS extraction strips execute permissions, so `setExecutablePermissions()` restores them on the extracted `venv/bin/` directory.

5. **`bootstrap.system_call_filter=false`** — Required for both test clusters because even with the privileged ProcessHandler, the seccomp-BPF filter operates at the kernel level and blocks `fork()`/`exec()` system calls. In production, this setting should be evaluated against the cluster's security requirements.

6. **Shared GraalVM Engine** — Compiled Truffle ASTs are cached in the engine and shared across all pooled contexts. This dramatically reduces warmup time: the first context takes ~15s to warm up, but subsequent contexts take ~2-5s because they reuse JIT-compiled code.

7. **State reset between uses** — After each execution, `resetContextState()` removes all non-system globals via `bindings.removeMember()`. The preserved `SYSTEM_GLOBALS` set (`__builtins__`, `__name__`, `__doc__`, `__package__`, `__loader__`, `__spec__`) is the minimum needed for a functional Python module scope. The module cache (`sys.modules`) is preserved so re-importing numpy is instant.

8. **Context replacement on timeout** — When a script times out (e.g., `while 1 == 1: pass`), the context is force-closed via `Context.close(true)` and a fresh replacement is created with numpy pre-loaded. This works reliably because `IsolateNativeModules=true` allows each new context to independently load native modules. The pool operates at reduced capacity during replacement.

9. **Dedicated fixed thread pool** — `pythonExecutor` with pool-size threads prevents GENERIC thread pool starvation. Callers block on `Future.get()` while Python execution happens on dedicated threads.

10. **Native POSIX backend for socket support** — `PosixModuleBackend` is set to `native` so Python's `socket` module works, enabling `urllib.request` for outbound HTTP(S) calls from scripts. The default `java` backend emulates POSIX through Truffle's abstraction layer which does not support socket operations.

11. **SSL certificate fix** — `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables are unset in each context during warmup. GraalPy's `set_default_verify_paths()` reads these env vars (inherited from the host via `EnvironmentAccess.INHERIT`) and tries to load the PEM file via `TruffleFile`. When the VFS cannot read the host path, the error is silently swallowed (`SSLContextBuiltins.java` in `oracle/graalpython`) and `useDefaultTrustStore` is never set to `true`, leaving the SSL context with zero CA certificates. Unsetting these env vars forces GraalPy to fall through to Java's default truststore (`$JAVA_HOME/lib/security/cacerts`), which contains valid CA certificates.

### Files changed

- **`ExecutionUtils.java`** — Complete rewrite: context pool with `IsolateNativeModules=true`, shared Engine, dedicated thread pool, ProcessHandler, `warmup()`, `closeContextPool()`, `resetContextState()`, `replaceContext()`, `setExecutablePermissions()`. Added `PosixModuleBackend=native` for socket support and SSL cert fix. Pool size is now configurable via `warmup(int)`.
- **`PythonModulePlugin.java`** — Synchronous warmup in `createComponents()`, `close()` override for pool shutdown. Added `script.python.context_pool_size` node setting with `getSettings()` registration.
- **`build.gradle`** — Bumped `org.graalvm.python` plugin and `compilerVersion` to 25.0.2. Added `patchelf==0.17.2.4`. Added `bootstrap.system_call_filter=false` for both test clusters.
- **`numpy.yml`** — Comprehensive test suite: single array test, 6 sequential multi-context tests, 10 array operation tests (matrix multiplication, slicing, statistics, transpose, linspace).
- **`README.md`** — Added `bootstrap.system_call_filter: false` note for binary distributions and updated version references to 3.4.0.
- **`docs/README.md`** — Added Configuration section documenting the `script.python.context_pool_size` setting.

## Comparison with #73 (single persistent context)

| Aspect | This PR (IsolateNativeModules=true) | #73 (IsolateNativeModules=false) |
|---|---|---|
| **Isolation** | Full — each context has isolated native lib copies | Partial — shared native `.so` in process memory |
| **Security** | No cross-context native state leakage possible | Native C globals shared across all executions |
| **Parallelism** | Up to configured pool size concurrent executions | Serialized (single-thread executor) |
| **Timeout recovery** | Replace context (new patchelf + numpy import) | `Context.interrupt()` (keeps context alive) |
| **Memory** | ~150MB per context (isolated `.so` copies) | ~150MB total (single context) |
| **Warmup time** | ~20s (2 contexts sequential) | ~15s (1 context) |
| **Dependencies** | Requires patchelf binary + seccomp disabled | No subprocess needed |

## Known limitations and potential issues

1. **`bootstrap.system_call_filter=false` required** — Patchelf needs `fork()`/`exec()` system calls during warmup. In production environments with strict security policies, disabling the system call filter may not be acceptable. A future improvement could use Java-based ELF SONAME patching to eliminate the subprocess dependency entirely.

2. **GraalPy C API is experimental** — Native extension support in GraalPy 25.0.2 is explicitly marked experimental. Known upstream issues:
   - [graalvm/graalpy#628](https://github.com/oracle/graalpy/issues/628): `TypeError: object.__init__()` with numpy multi-context
   - [graalvm/graalpy#563](https://github.com/oracle/graalpy/issues/563): SIGSEGV with concurrent context native module loading
   - These bugs have not manifested in our testing (sequential warmup + pool reuse avoids the problematic concurrent loading patterns), but they represent risk for future GraalPy updates.

3. **Warmup blocks node startup** — Creating contexts with numpy takes time proportional to pool size, during which the node cannot serve requests. This is a one-time cost. The shared Engine makes subsequent context creation (e.g., replacements after timeout) faster (~2-5s).

4. **Pool exhaustion under load** — With the default pool size, concurrent Python requests beyond the pool size will block until a context is returned. The pool size can be tuned via `script.python.context_pool_size` in `opensearch.yml`, but each additional context adds ~150MB of memory for the isolated native library copies.

5. **Context replacement cost** — When a timeout destroys a context, the replacement takes ~5s (patchelf + numpy import with cached JIT code). During replacement, pool capacity is reduced by 1.

6. **Disk space for isolated `.so` copies** — Each context's patchelf-patched copies consume ~50MB on disk. Total disk usage scales linearly with pool size.

## Test plan

- [x] All 17 yamlRestTest tests pass (verified across 3 consecutive runs including a clean build)
- [x] `basic_expressions.yml` — string concat, math.sqrt, json.dumps
- [x] `numpy.yml` — single array, 6 sequential multi-context operations, 10 array operations
- [x] `isolate_contexts.yml` — variable isolation between executions
- [x] `escape_loop.yml` — infinite loop detection and timeout
- [x] `field_script.yml`, `score_script.yml`, `search_script.yml`, `ingest_script.yml` — script context integrations